### PR TITLE
Fixed the docs by adding the swagger resources to the CSP header

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,7 +42,11 @@ async def add_security_headers(request, call_next):
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-XSS-Protection"] = "1; mode=block"
     response.headers["Content-Security-Policy"] = (
-        "default-src 'self'; script-src 'self'"
+        "default-src 'self'; "
+        "script-src 'self' https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js 'sha256-QOOQu4W1oxGqd2nbXbxiA1Di6OHQOLQD+o+G9oWL8YY='; "
+        "style-src 'self' https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css; "
+        "img-src 'self' https://fastapi.tiangolo.com; http://www.w3.org/2000/svg;"
+        "frame-ancestors 'none'"
     )
 
     return response


### PR DESCRIPTION
Instead of serving the swagger images, JS and CSS from the same origin just added them to the Content Security Policy.