### PR TITLE
Improved security and found an easy way to test with curl

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@ import os
 import uvicorn
 from fastapi import FastAPI, status
 from fastapi.responses import JSONResponse
-from fastapi.staticfiles import StaticFiles  # to delete
 from fastapi.middleware.cors import CORSMiddleware
 from routes import users, auth
 from database import Base, engine
@@ -13,7 +12,6 @@ from models.users import User
 SECRET_KEY = os.getenv("SECRET_KEY")
 
 app = FastAPI()
-app.mount("/static", StaticFiles(directory="static"), name="static")  # to delete
 Base.metadata.create_all(bind=engine)
 app.include_router(users.router)
 app.include_router(auth.router)

--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ async def add_security_headers(request, call_next):
         "default-src 'self'; "
         "script-src 'self' https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js 'sha256-QOOQu4W1oxGqd2nbXbxiA1Di6OHQOLQD+o+G9oWL8YY='; "
         "style-src 'self' https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css; "
-        "img-src 'self' https://fastapi.tiangolo.com; http://www.w3.org/2000/svg;"
+        "img-src 'self' https://fastapi.tiangolo.com data:; http://www.w3.org/2000/svg;"
         "frame-ancestors 'none'"
     )
 

--- a/manual_test.html
+++ b/manual_test.html
@@ -165,6 +165,7 @@
                     resultDiv.innerText = `Success: ${data.detail}`;
                     resultDiv.style.backgroundColor = 'lightgreen';
                     resultDiv.style.visibility = 'visible';
+
                 } else {
                     const errorData = await response.json();
                     resultDiv.innerText = `Error: ${errorData.detail}`;
@@ -198,6 +199,7 @@
 
                 if (response.ok) {
                     const data = await response.json();
+                    document.cookie = `csrf_token=${data.csrf_token}; path=/; max-age=1800; samesite=Strict`;
                     loginResultDiv.innerText = `Success: ${data.detail}`;
                     loginResultDiv.style.backgroundColor = 'lightgreen';
                     loginResultDiv.style.visibility = 'visible';
@@ -291,11 +293,10 @@
             e.preventDefault();
 
             try {
-                const response = await fetch('http://127.0.0.1:8000/csrf_token', { method: 'GET' });
+                const response = await fetch('http://127.0.0.1:8000/csrf_token', { method: 'GET', credentials: 'include' });
 
                 if (response.ok) {
                     const data = await response.json();
-                    document.cookie = `csrf_token=${data.csrf_token}; path=/; max-age=1800; samesite=Strict`;
                     csrfResultDiv.innerText = `Success: ${data.detail}`;
                     csrfResultDiv.style.backgroundColor = 'lightgreen';
                     csrfResultDiv.style.visibility = 'visible';
@@ -312,11 +313,7 @@
                 csrfResultDiv.style.visibility = 'visible';
             }
         });
-        fetch('http://127.0.0.1:8000/csrf_token')
-            .then(response => response.json())
-            .then(data => {
-                document.cookie = `csrf_token=${data.csrf_token}; path=/; max-age=1800; samesite=Strict`;
-            })
+        fetch('http://127.0.0.1:8000/csrf_token', { method: 'GET', credentials: 'include' })
             .catch(error => console.error('Error:', error));
     </script>
 </body>

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -44,7 +44,7 @@ async def get_current_user(db: db_dependency, access_token: str = Cookie(None)):
 
 
 def csrf_validator(request: Request):
-    cookie_csrf_token = request.cookies.get("csrf_token")
+    cookie_csrf_token = request.cookies.get("csrf_token2")
     header_csrf_token = request.headers.get("X-CSRF-Token")
     if not header_csrf_token or header_csrf_token != cookie_csrf_token:
         raise HTTPException(
@@ -75,7 +75,8 @@ async def login_for_access_token(
     csrf_token = secrets.token_urlsafe(32)
     access_token = create_access_token(user.email, timedelta(minutes=30))
     response = JSONResponse(
-        content={"detail": "Logged in successfully"}, status_code=status.HTTP_200_OK
+        content={"detail": "Logged in successfully"},
+        status_code=status.HTTP_200_OK,
     )
     response.set_cookie(
         "access_token",
@@ -89,6 +90,16 @@ async def login_for_access_token(
     )
     response.set_cookie(
         "csrf_token",
+        csrf_token,
+        max_age=1800,
+        domain=None,
+        path="/",
+        secure=True,
+        httponly=False,
+        samesite="Strict",
+    )
+    response.set_cookie(
+        "csrf_token2",
         csrf_token,
         max_age=1800,
         domain=None,
@@ -113,7 +124,27 @@ async def logout(user: auth_user_dependency, crsf_token: csrf_dependency):
 async def get_token():
     csrf_token = secrets.token_urlsafe(32)
     response = JSONResponse(
-        content={"detail": "CSRF Token set", "csrf_token": csrf_token},
+        content={"detail": "CSRF Token set"},
         status_code=status.HTTP_200_OK,
+    )
+    response.set_cookie(
+        "csrf_token",
+        csrf_token,
+        max_age=1800,
+        domain=None,
+        path="/",
+        secure=True,
+        httponly=False,
+        samesite="Strict",
+    )
+    response.set_cookie(
+        "csrf_token2",
+        csrf_token,
+        max_age=1800,
+        domain=None,
+        path="/",
+        secure=True,
+        httponly=True,
+        samesite="Strict",
     )
     return response


### PR DESCRIPTION
## Easy way to test with curl/Postman:
1. Log in using the manual_test.html
2. Get the cookies from the browser
3. Use the cookies to build your request

Example (authenticated user + csrf protection):
curl -X 'DELETE' \
  'http://localhost:8000/users/delete' \
  -H 'accept: application/json' \
  -H 'X-CSRF-Token: wNQrktZOSgYAJ9oQfcjN_tQIw22GLdnOfNZfTkgIPE8' \
  -H 'Cookie: csrf_token2=wNQrktZOSgYAJ9oQfcjN_tQIw22GLdnOfNZfTkgIPE8;access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhQGFidi5iZyIsImV4cCI6MTc0MjMzMTQ0M30.Qmqq6tYRAvVb9GsqCQh5II_isJkrepbSOKbuFJ6QKKI'